### PR TITLE
Add Home Assistant integration with learning UI

### DIFF
--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,1 @@
+"""Custom components namespace for RaspyRFM integration."""

--- a/custom_components/raspyrfm/__init__.py
+++ b/custom_components/raspyrfm/__init__.py
@@ -1,0 +1,53 @@
+"""Home Assistant integration for the RaspyRFM gateway."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .const import DOMAIN, PLATFORMS
+from .hub import RaspyRFMHub
+from .panel import async_register_panel, async_unregister_panel
+from .websocket import async_register_websocket_handlers
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up RaspyRFM from a config entry."""
+    hub = RaspyRFMHub(hass, entry)
+
+    try:
+        await hub.async_setup()
+    except OSError as err:
+        raise ConfigEntryNotReady("Unable to initialise RaspyRFM hub") from err
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = hub
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    await async_register_panel(hass, entry)
+    async_register_websocket_handlers(hass)
+
+    entry.async_on_unload(entry.add_update_listener(async_update_entry))
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a RaspyRFM config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hub = hass.data[DOMAIN].pop(entry.entry_id)
+        await hub.async_unload()
+        await async_unregister_panel(hass, entry)
+
+    return unload_ok
+
+
+async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    hub: RaspyRFMHub = hass.data[DOMAIN][entry.entry_id]
+    await hub.async_update_entry(entry)

--- a/custom_components/raspyrfm/binary_sensor.py
+++ b/custom_components/raspyrfm/binary_sensor.py
@@ -1,0 +1,88 @@
+"""Binary sensor platform for RaspyRFM."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import DOMAIN, SIGNAL_DEVICE_REGISTRY_UPDATED, SIGNAL_SIGNAL_RECEIVED
+from .entity import RaspyRFMEntity
+from .hub import RaspyRFMHub
+from .storage import RaspyRFMDeviceEntry
+
+RESET_TIMEOUT = 5
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    hub: RaspyRFMHub = hass.data[DOMAIN][entry.entry_id]
+    entities: Dict[str, RaspyRFMBinarySensor] = {}
+
+    @callback
+    def _ensure_entities() -> None:
+        new_entities = []
+        for device in hub.storage.iter_devices_by_type("binary_sensor"):
+            if device.device_id in entities:
+                continue
+            entity = RaspyRFMBinarySensor(hub, device)
+            entities[device.device_id] = entity
+            new_entities.append(entity)
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _ensure_entities()
+
+    @callback
+    def handle_device_update(device_id: str | None) -> None:
+        if device_id is None or device_id not in entities:
+            _ensure_entities()
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_DEVICE_REGISTRY_UPDATED, handle_device_update)
+    )
+
+
+class RaspyRFMBinarySensor(RaspyRFMEntity, BinarySensorEntity):
+    """Representation of a learned binary sensor."""
+
+    def __init__(self, hub: RaspyRFMHub, device: RaspyRFMDeviceEntry) -> None:
+        super().__init__(hub, device)
+        self._reset_handle: asyncio.TimerHandle | None = None
+        self._signal_unsub = None
+        self._attr_is_on = False
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        @callback
+        def handle_signal(event: Dict[str, Any]) -> None:
+            payload = event.get("payload")
+            if payload not in self._device.signals.values():
+                return
+            self._attr_is_on = True
+            self.async_write_ha_state()
+            if self._reset_handle is not None:
+                self._reset_handle.cancel()
+            self._reset_handle = self.hass.loop.call_later(RESET_TIMEOUT, self._reset_state)
+
+        self._signal_unsub = async_dispatcher_connect(
+            self.hass, SIGNAL_SIGNAL_RECEIVED, handle_signal
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._signal_unsub is not None:
+            self._signal_unsub()
+            self._signal_unsub = None
+        if self._reset_handle is not None:
+            self._reset_handle.cancel()
+            self._reset_handle = None
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _reset_state(self) -> None:
+        self._reset_handle = None
+        self._attr_is_on = False
+        self.async_write_ha_state()

--- a/custom_components/raspyrfm/config_flow.py
+++ b/custom_components/raspyrfm/config_flow.py
@@ -1,0 +1,81 @@
+"""Config flow for the RaspyRFM integration."""
+
+from __future__ import annotations
+
+import socket
+from typing import Any, Dict
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_HOST, CONF_PORT, DEFAULT_PORT, DOMAIN
+
+
+async def _validate_input(hass: HomeAssistant, data: Dict[str, Any]) -> Dict[str, Any]:
+    host = data[CONF_HOST]
+    port = data[CONF_PORT]
+
+    def _resolve() -> str:
+        return socket.gethostbyname(host)
+
+    await hass.async_add_executor_job(_resolve)
+    return {"title": f"RaspyRFM ({host})", "host": host, "port": port}
+
+
+class RaspyRFMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for RaspyRFM."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: Dict[str, Any] | None = None):
+        errors: Dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                info = await _validate_input(self.hass, user_input)
+            except OSError:
+                errors["base"] = "cannot_connect"
+            else:
+                await self.async_set_unique_id(user_input[CONF_HOST])
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        schema = vol.Schema({
+            vol.Required(CONF_HOST): str,
+            vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+        })
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    async def async_step_import(self, user_input: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle YAML import."""
+
+        return await self.async_step_user(user_input)
+
+    async def async_get_options_flow(self, entry: config_entries.ConfigEntry):
+        return RaspyRFMOptionsFlow(entry)
+
+
+class RaspyRFMOptionsFlow(config_entries.OptionsFlow):
+    """Handle options flow for RaspyRFM."""
+
+    def __init__(self, entry: config_entries.ConfigEntry) -> None:
+        self._entry = entry
+
+    async def async_step_init(self, user_input: Dict[str, Any] | None = None):
+        errors: Dict[str, str] = {}
+
+        if user_input is not None:
+            new_data = {
+                CONF_HOST: user_input[CONF_HOST],
+                CONF_PORT: user_input[CONF_PORT],
+            }
+            self.hass.config_entries.async_update_entry(self._entry, data=new_data)
+            return self.async_create_entry(title="", data={})
+
+        schema = vol.Schema({
+            vol.Required(CONF_HOST, default=self._entry.data.get(CONF_HOST)): str,
+            vol.Required(CONF_PORT, default=self._entry.data.get(CONF_PORT, DEFAULT_PORT)): int,
+        })
+        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)

--- a/custom_components/raspyrfm/const.py
+++ b/custom_components/raspyrfm/const.py
@@ -1,0 +1,37 @@
+"""Constants for the RaspyRFM Home Assistant integration."""
+
+from __future__ import annotations
+
+from homeassistant.const import Platform
+
+DOMAIN = "raspyrfm"
+CONF_HOST = "host"
+CONF_PORT = "port"
+DEFAULT_PORT = 49880
+DEFAULT_LISTEN_PORT = 49881
+
+PLATFORMS: list[Platform] = [Platform.SWITCH, Platform.BINARY_SENSOR]
+
+STORAGE_VERSION = 1
+STORAGE_KEY = f"{DOMAIN}_devices"
+
+SIGNAL_DEVICE_REGISTRY_UPDATED = "raspyrfm_device_registry_updated"
+SIGNAL_DEVICE_REMOVED = "raspyrfm_device_removed"
+SIGNAL_SIGNAL_RECEIVED = "raspyrfm_signal_received"
+SIGNAL_LEARNING_STATE = "raspyrfm_learning_state"
+
+PANEL_URL_PATH = "raspyrfm"
+PANEL_ICON = "mdi:radio-tower"
+PANEL_TITLE = "RaspyRFM"
+
+WS_TYPE_PREFIX = "raspyrfm/"
+WS_TYPE_LEARNING_START = WS_TYPE_PREFIX + "learning/start"
+WS_TYPE_LEARNING_STOP = WS_TYPE_PREFIX + "learning/stop"
+WS_TYPE_LEARNING_SUBSCRIBE = WS_TYPE_PREFIX + "learning/subscribe"
+WS_TYPE_LEARNING_STATUS = WS_TYPE_PREFIX + "learning/status"
+WS_TYPE_SIGNALS_LIST = WS_TYPE_PREFIX + "signals/list"
+WS_TYPE_SIGNALS_SUBSCRIBE = WS_TYPE_PREFIX + "signals/subscribe"
+WS_TYPE_DEVICE_CREATE = WS_TYPE_PREFIX + "device/create"
+WS_TYPE_DEVICE_DELETE = WS_TYPE_PREFIX + "device/delete"
+WS_TYPE_DEVICE_LIST = WS_TYPE_PREFIX + "devices/list"
+WS_TYPE_DEVICE_RELOAD = WS_TYPE_PREFIX + "devices/reload"

--- a/custom_components/raspyrfm/entity.py
+++ b/custom_components/raspyrfm/entity.py
@@ -1,0 +1,57 @@
+"""Base entity classes for the RaspyRFM integration."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+
+from .const import DOMAIN, SIGNAL_DEVICE_REGISTRY_UPDATED
+from .hub import RaspyRFMHub
+from .storage import RaspyRFMDeviceEntry
+
+
+class RaspyRFMEntity(Entity):
+    """Common representation of a RaspyRFM entity."""
+
+    _attr_should_poll = False
+
+    def __init__(self, hub: RaspyRFMHub, device: RaspyRFMDeviceEntry) -> None:
+        self._hub = hub
+        self._device = device
+        self._unsub_dispatcher = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        def _handle_update(device_id: str | None) -> None:
+            if device_id is None or device_id == self._device.device_id:
+                new_device = self._hub.get_device(self._device.device_id)
+                if new_device:
+                    self._device = new_device
+                self.async_write_ha_state()
+
+        self._unsub_dispatcher = async_dispatcher_connect(
+            self.hass, SIGNAL_DEVICE_REGISTRY_UPDATED, _handle_update
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._unsub_dispatcher is not None:
+            self._unsub_dispatcher()
+            self._unsub_dispatcher = None
+        await super().async_will_remove_from_hass()
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, self._hub.gateway.host)},
+            "manufacturer": "Seegel Systeme",
+            "name": "RaspyRFM",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        return self._device.device_id
+
+    @property
+    def name(self) -> str:
+        return self._device.name

--- a/custom_components/raspyrfm/frontend/raspyrfm-panel.js
+++ b/custom_components/raspyrfm/frontend/raspyrfm-panel.js
@@ -1,0 +1,364 @@
+const { LitElement, html, css } = window;
+
+class RaspyRFMPanel extends LitElement {
+  static get properties() {
+    return {
+      hass: {},
+      learning: { type: Boolean },
+      signals: { state: true },
+      devices: { state: true },
+      formType: { state: true },
+      formName: { state: true },
+      formOn: { state: true },
+      formOff: { state: true },
+      formTrigger: { state: true },
+      error: { state: true },
+    };
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+        padding: 24px;
+      }
+      .actions {
+        display: flex;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+      ha-card {
+        margin-bottom: 16px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th, td {
+        padding: 8px;
+        border-bottom: 1px solid var(--divider-color);
+      }
+      .signal-list {
+        max-height: 300px;
+        overflow-y: auto;
+      }
+      .signal-entry {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 8px;
+        border-bottom: 1px solid var(--divider-color);
+      }
+      .signal-entry:last-child {
+        border-bottom: none;
+      }
+      .signal-meta {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+      }
+      .form-grid {
+        display: grid;
+        gap: 12px;
+      }
+      .form-row {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+      }
+      .pill {
+        padding: 2px 8px;
+        border-radius: 12px;
+        background-color: var(--accent-color);
+        color: var(--text-primary-color);
+        font-size: 12px;
+      }
+      .error {
+        color: var(--error-color);
+        margin-bottom: 12px;
+      }
+    `;
+  }
+
+  constructor() {
+    super();
+    this.learning = false;
+    this.signals = [];
+    this.devices = [];
+    this.formType = "switch";
+    this.formName = "";
+    this.formOn = null;
+    this.formOff = null;
+    this.formTrigger = null;
+    this.error = null;
+    this._signalUnsub = null;
+    this._learningUnsub = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._initialize();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._signalUnsub) {
+      this._signalUnsub();
+      this._signalUnsub = null;
+    }
+    if (this._learningUnsub) {
+      this._learningUnsub();
+      this._learningUnsub = null;
+    }
+  }
+
+  async _initialize() {
+    await this._loadState();
+    await this._subscribeSignals();
+    await this._subscribeLearning();
+    await this._refreshDevices();
+  }
+
+  async _loadState() {
+    const status = await this.hass.callWS({ type: "raspyrfm/learning/status" });
+    this.learning = status.active;
+    const signals = await this.hass.callWS({ type: "raspyrfm/signals/list" });
+    this.signals = signals.signals || [];
+  }
+
+  async _subscribeSignals() {
+    this._signalUnsub = await this.hass.connection.subscribeMessage((message) => {
+      if (message.type !== "event") {
+        return;
+      }
+      const signal = message.event;
+      this.signals = [...this.signals, signal];
+    }, {
+      type: "raspyrfm/signals/subscribe"
+    });
+  }
+
+  async _subscribeLearning() {
+    this._learningUnsub = await this.hass.connection.subscribeMessage((message) => {
+      if (message.type !== "event") {
+        return;
+      }
+      this.learning = message.event.active;
+    }, {
+      type: "raspyrfm/learning/subscribe"
+    });
+  }
+
+  async _refreshDevices() {
+    const response = await this.hass.callWS({ type: "raspyrfm/devices/list" });
+    this.devices = response.devices || [];
+  }
+
+  render() {
+    return html`
+      <div class="actions">
+        <mwc-button raised @click=${this._handleStartLearning} ?disabled=${this.learning}>Start learning</mwc-button>
+        <mwc-button @click=${this._handleStopLearning} ?disabled=${!this.learning}>Stop learning</mwc-button>
+        <mwc-button @click=${this._refreshDevices}>Refresh devices</mwc-button>
+      </div>
+      ${this.error ? html`<div class="error">${this.error}</div>` : ""}
+      ${this._renderSignals()}
+      ${this._renderForm()}
+      ${this._renderDevices()}
+    `;
+  }
+
+  _renderSignals() {
+    if (!this.signals.length) {
+      return html`
+        <ha-card header="Captured signals">
+          <div class="card-content">No signals received yet. Use the start learning button and trigger your remotes or sensors.</div>
+        </ha-card>
+      `;
+    }
+    return html`
+      <ha-card header="Captured signals">
+        <div class="card-content signal-list">
+          ${this.signals.map((signal) => this._renderSignal(signal))}
+        </div>
+      </ha-card>
+    `;
+  }
+
+  _renderSignal(signal) {
+    return html`
+      <div class="signal-entry">
+        <div>
+          <div>${signal.payload}</div>
+          <div class="signal-meta">${signal.received}</div>
+        </div>
+        <div class="form-row">
+          <mwc-button dense @click=${() => this._selectSignal(signal.payload, "on")}>Set as ON</mwc-button>
+          <mwc-button dense @click=${() => this._selectSignal(signal.payload, "off")}>Set as OFF</mwc-button>
+          <mwc-button dense @click=${() => this._selectSignal(signal.payload, "trigger")}>Set as trigger</mwc-button>
+        </div>
+      </div>
+    `;
+  }
+
+  _renderForm() {
+    return html`
+      <ha-card header="Create Home Assistant device">
+        <div class="card-content form-grid">
+          <div class="form-row">
+            <ha-textfield label="Name" .value=${this.formName} @input=${(ev) => this._updateName(ev.target.value)}></ha-textfield>
+            <ha-select label="Type" .value=${this.formType} @selected=${(ev) => this._updateType(ev.target.value)}>
+              <mwc-list-item value="switch">Switch</mwc-list-item>
+              <mwc-list-item value="binary_sensor">Binary sensor</mwc-list-item>
+            </ha-select>
+          </div>
+          ${this.formType === "switch"
+            ? html`
+                <div class="form-row">
+                  <span class="pill">ON</span>
+                  <span>${this.formOn || "Choose a captured signal"}</span>
+                </div>
+                <div class="form-row">
+                  <span class="pill">OFF</span>
+                  <span>${this.formOff || "Optional"}</span>
+                </div>
+              `
+            : html`
+                <div class="form-row">
+                  <span class="pill">Trigger</span>
+                  <span>${this.formTrigger || "Choose a captured signal"}</span>
+                </div>
+              `}
+          <div>
+            <mwc-button raised @click=${this._createDevice}>Create device</mwc-button>
+          </div>
+        </div>
+      </ha-card>
+    `;
+  }
+
+  _renderDevices() {
+    if (!this.devices.length) {
+      return html`
+        <ha-card header="Configured devices">
+          <div class="card-content">No RaspyRFM devices created yet.</div>
+        </ha-card>
+      `;
+    }
+    return html`
+      <ha-card header="Configured devices">
+        <div class="card-content">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Signals</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              ${this.devices.map((device) => html`
+                <tr>
+                  <td>${device.name}</td>
+                  <td>${device.device_type}</td>
+                  <td>
+                    ${Object.entries(device.signals || {}).map(([key, value]) => html`<div><strong>${key}</strong>: ${value}</div>`) }
+                  </td>
+                  <td>
+                    <mwc-button @click=${() => this._deleteDevice(device.device_id)}>Delete</mwc-button>
+                  </td>
+                </tr>
+              `)}
+            </tbody>
+          </table>
+        </div>
+      </ha-card>
+    `;
+  }
+
+  _updateName(value) {
+    this.formName = value;
+  }
+
+  _updateType(value) {
+    this.formType = value;
+  }
+
+  _selectSignal(payload, target) {
+    if (this.formType === "switch") {
+      if (target === "on") {
+        this.formOn = payload;
+      } else if (target === "off") {
+        this.formOff = payload;
+      } else {
+        this.error = "Switches do not use trigger signals";
+        return;
+      }
+    } else {
+      this.formTrigger = payload;
+    }
+    this.error = null;
+    this.requestUpdate();
+  }
+
+  async _createDevice() {
+    this.error = null;
+    const name = this.formName.trim();
+    if (!name) {
+      this.error = "Please provide a device name.";
+      return;
+    }
+
+    const signals = {};
+    if (this.formType === "switch") {
+      if (!this.formOn) {
+        this.error = "Select an ON signal for the switch.";
+        return;
+      }
+      signals.on = this.formOn;
+      if (this.formOff) {
+        signals.off = this.formOff;
+      }
+    } else {
+      if (!this.formTrigger) {
+        this.error = "Select a trigger signal for the sensor.";
+        return;
+      }
+      signals.trigger = this.formTrigger;
+    }
+
+    try {
+      await this.hass.callWS({
+        type: "raspyrfm/device/create",
+        name,
+        device_type: this.formType,
+        signals,
+      });
+      await this._refreshDevices();
+      this.formName = "";
+      this.formOn = null;
+      this.formOff = null;
+      this.formTrigger = null;
+      this.error = null;
+    } catch (err) {
+      this.error = err?.message || "Failed to create device";
+    }
+  }
+
+  async _deleteDevice(deviceId) {
+    await this.hass.callWS({ type: "raspyrfm/device/delete", device_id: deviceId });
+    await this._refreshDevices();
+  }
+
+  async _handleStartLearning() {
+    await this.hass.callWS({ type: "raspyrfm/learning/start" });
+    this.learning = true;
+  }
+
+  async _handleStopLearning() {
+    await this.hass.callWS({ type: "raspyrfm/learning/stop" });
+    this.learning = false;
+  }
+}
+
+customElements.define("raspyrfm-panel", RaspyRFMPanel);

--- a/custom_components/raspyrfm/gateway.py
+++ b/custom_components/raspyrfm/gateway.py
@@ -1,0 +1,54 @@
+"""Helpers for interacting with the RaspyRFM UDP gateway."""
+
+from __future__ import annotations
+import logging
+import socket
+
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RaspyRFMGateway:
+    """Abstraction around the UDP based RaspyRFM gateway."""
+
+    def __init__(self, hass: HomeAssistant, host: str, port: int) -> None:
+        self._hass = hass
+        self._host = host
+        self._port = port
+
+    @property
+    def host(self) -> str:
+        """Return the configured host."""
+
+        return self._host
+
+    @property
+    def port(self) -> int:
+        """Return the configured port."""
+
+        return self._port
+
+    async def async_update(self, host: str, port: int) -> None:
+        """Update connection details."""
+
+        self._host = host
+        self._port = port
+
+    async def async_send_raw(self, payload: str) -> None:
+        """Send a raw payload to the gateway via UDP."""
+
+        if not self._host:
+            raise OSError("Gateway host not configured")
+
+        def _send() -> None:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.settimeout(2)
+                sock.sendto(payload.encode("utf-8"), (self._host, self._port))
+
+        await self._hass.async_add_executor_job(_send)
+
+    async def async_ping(self) -> None:
+        """Attempt to contact the gateway."""
+
+        await self.async_send_raw("PING")

--- a/custom_components/raspyrfm/hub.py
+++ b/custom_components/raspyrfm/hub.py
@@ -1,0 +1,199 @@
+"""Core hub object for the RaspyRFM integration."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+import logging
+import socket
+import uuid
+from typing import Any, Dict, Iterable, List, Optional
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .const import (
+    CONF_HOST,
+    CONF_PORT,
+    DEFAULT_PORT,
+    DOMAIN,
+    SIGNAL_DEVICE_REGISTRY_UPDATED,
+    SIGNAL_DEVICE_REMOVED,
+    SIGNAL_LEARNING_STATE,
+    SIGNAL_SIGNAL_RECEIVED,
+)
+from .storage import RaspyRFMDeviceEntry, RaspyRFMDeviceStorage
+from .gateway import RaspyRFMGateway
+from .learn import LearnManager, LearnedSignal
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ActiveSignal:
+    """Representation of a signal currently known to the hub."""
+
+    signal: LearnedSignal
+    received_at: datetime
+    source: tuple[str, int]
+
+
+class RaspyRFMHub:
+    """Bridge between Home Assistant and a RaspyRFM gateway."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        self._hass = hass
+        self._entry = entry
+        self._gateway = RaspyRFMGateway(
+            hass,
+            entry.data.get(CONF_HOST, ""),
+            entry.data.get(CONF_PORT, DEFAULT_PORT),
+        )
+        self._storage = RaspyRFMDeviceStorage(hass)
+        self._learn_manager = LearnManager(hass, self)
+        self._active_signals: Dict[str, ActiveSignal] = {}
+        self._signals_lock = asyncio.Lock()
+
+    @property
+    def gateway(self) -> RaspyRFMGateway:
+        """Return the gateway helper object."""
+
+        return self._gateway
+
+    @property
+    def storage(self) -> RaspyRFMDeviceStorage:
+        """Return the persistent storage helper."""
+
+        return self._storage
+
+    @property
+    def learn_manager(self) -> LearnManager:
+        """Return the signal learning manager."""
+
+        return self._learn_manager
+
+    async def async_setup(self) -> None:
+        """Initialise hub resources."""
+
+        await self._storage.async_load()
+
+    async def async_unload(self) -> None:
+        """Unload hub resources."""
+
+        await self._learn_manager.async_stop()
+        await self._storage.async_unload()
+
+    async def async_update_entry(self, entry: ConfigEntry) -> None:
+        """Handle entry updates."""
+
+        self._entry = entry
+        await self._gateway.async_update(  # type: ignore[no-untyped-call]
+            entry.data.get(CONF_HOST, ""), entry.data.get(CONF_PORT, DEFAULT_PORT)
+        )
+
+    async def async_start_learning(self) -> None:
+        """Start a learning session."""
+
+        async with self._signals_lock:
+            self._active_signals.clear()
+        await self._learn_manager.async_start()
+
+    async def async_stop_learning(self) -> None:
+        """Stop an active learning session."""
+
+        await self._learn_manager.async_stop()
+
+    def iter_devices(self) -> Iterable[RaspyRFMDeviceEntry]:
+        """Return all configured devices."""
+
+        return self._storage.iter_devices()
+
+    def get_device(self, device_id: str) -> Optional[RaspyRFMDeviceEntry]:
+        """Return a device by id."""
+
+        return self._storage.get_device(device_id)
+
+    async def async_create_device(
+        self,
+        name: str,
+        device_type: str,
+        signals: Dict[str, str],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> RaspyRFMDeviceEntry:
+        """Create a new device entry from learned signals."""
+
+        device = RaspyRFMDeviceEntry(
+            device_id=str(uuid.uuid4()),
+            name=name,
+            device_type=device_type,
+            signals=signals,
+            metadata=metadata or {},
+        )
+        await self._storage.async_add_or_update(device)
+        async_dispatcher_send(self._hass, SIGNAL_DEVICE_REGISTRY_UPDATED, device.device_id)
+        return device
+
+    async def async_remove_device(self, device_id: str) -> None:
+        """Remove a device entry."""
+
+        await self._storage.async_remove(device_id)
+        async_dispatcher_send(self._hass, SIGNAL_DEVICE_REMOVED, device_id)
+
+    async def async_handle_learned_signal(self, signal: LearnedSignal, addr: tuple[str, int]) -> None:
+        """Handle a signal received during a learning session."""
+
+        async with self._signals_lock:
+            self._active_signals[signal.uid] = ActiveSignal(
+                signal=signal, received_at=datetime.utcnow(), source=addr
+            )
+        async_dispatcher_send(
+            self._hass,
+            SIGNAL_SIGNAL_RECEIVED,
+            signal.to_dict(),
+        )
+        await self._maybe_match_devices(signal)
+
+    async def _maybe_match_devices(self, signal: LearnedSignal) -> None:
+        """Match a learned signal with configured devices and fire updates."""
+
+        matched: List[str] = []
+        for device in self._storage.iter_devices():
+            if device.matches_signal(signal.payload):
+                matched.append(device.device_id)
+
+        if not matched:
+            return
+
+        for device_id in matched:
+            async_dispatcher_send(self._hass, SIGNAL_DEVICE_REGISTRY_UPDATED, device_id)
+
+    async def async_list_active_signals(self) -> List[Dict[str, Any]]:
+        """Return a snapshot of all active signals."""
+
+        async with self._signals_lock:
+            return [signal.signal.to_dict() for signal in self._active_signals.values()]
+
+    async def async_reload_devices(self) -> None:
+        """Reload device information from disk."""
+
+        await self._storage.async_load()
+        async_dispatcher_send(self._hass, SIGNAL_DEVICE_REGISTRY_UPDATED, None)
+
+    async def async_record_learning_state(self, active: bool) -> None:
+        """Announce a change of the learning state."""
+
+        async_dispatcher_send(self._hass, SIGNAL_LEARNING_STATE, {"active": active})
+
+    async def async_send_raw(self, payload: str) -> None:
+        """Send a raw UDP payload to the gateway."""
+
+        await self._gateway.async_send_raw(payload)
+
+
+async def resolve_host(host: str) -> str:
+    """Resolve a host to an IP address."""
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, socket.gethostbyname, host)

--- a/custom_components/raspyrfm/learn.py
+++ b/custom_components/raspyrfm/learn.py
@@ -1,0 +1,129 @@
+"""Signal learning helper for the RaspyRFM integration."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from homeassistant.core import HomeAssistant
+from .const import DEFAULT_LISTEN_PORT
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class LearnedSignal:
+    """Representation of a learned radio signal."""
+
+    uid: str
+    payload: str
+    received: datetime
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation."""
+
+        return {
+            "uid": self.uid,
+            "payload": self.payload,
+            "received": self.received.isoformat(),
+            "metadata": self.metadata,
+        }
+
+
+class RaspyRFMLearnProtocol(asyncio.DatagramProtocol):
+    """Asyncio datagram protocol for capturing signals."""
+
+    def __init__(self, manager: "LearnManager") -> None:
+        self._manager = manager
+
+    def datagram_received(self, data: bytes, addr: Tuple[str, int]) -> None:
+        payload = data.decode("utf-8", errors="ignore").strip()
+        if not payload:
+            return
+
+        asyncio.create_task(self._manager.async_process_datagram(payload, addr))
+
+
+class LearnManager:
+    """Manage RaspyRFM learning sessions."""
+
+    def __init__(self, hass: HomeAssistant, hub: "RaspyRFMHub") -> None:
+        self._hass = hass
+        self._hub = hub
+        self._transport: Optional[asyncio.transports.DatagramTransport] = None
+        self._active = False
+        self._listen_port = DEFAULT_LISTEN_PORT
+        self._signals: List[LearnedSignal] = []
+        self._lock = asyncio.Lock()
+
+    @property
+    def is_active(self) -> bool:
+        """Return whether learning is active."""
+
+        return self._active
+
+    async def async_start(self) -> None:
+        """Start listening for incoming datagrams."""
+
+        if self._active:
+            return
+
+        loop = asyncio.get_running_loop()
+        self._transport, _ = await loop.create_datagram_endpoint(
+            lambda: RaspyRFMLearnProtocol(self), local_addr=("0.0.0.0", self._listen_port)
+        )
+        self._signals.clear()
+        self._active = True
+        try:
+            await self._hub.async_send_raw("RXSTART")
+        except OSError:
+            _LOGGER.debug("Unable to send RXSTART command to gateway")
+        await self._hub.async_record_learning_state(True)
+
+    async def async_stop(self) -> None:
+        """Stop listening for signals."""
+
+        if not self._active:
+            return
+
+        if self._transport is not None:
+            self._transport.close()
+            self._transport = None
+        self._active = False
+        try:
+            await self._hub.async_send_raw("RXSTOP")
+        except OSError:
+            _LOGGER.debug("Unable to send RXSTOP command to gateway")
+        await self._hub.async_record_learning_state(False)
+
+    async def async_process_datagram(self, payload: str, addr: Tuple[str, int]) -> None:
+        """Process an incoming UDP datagram."""
+
+        if not payload:
+            return
+
+        signal = LearnedSignal(
+            uid=f"sig_{len(self._signals)+1}",
+            payload=payload,
+            received=datetime.utcnow(),
+            metadata={"source": addr[0], "port": addr[1]},
+        )
+        async with self._lock:
+            self._signals.append(signal)
+        await self._hub.async_handle_learned_signal(signal, addr)
+
+    async def async_list_signals(self) -> List[Dict[str, Any]]:
+        """Return a list of captured signals."""
+
+        async with self._lock:
+            return [signal.to_dict() for signal in self._signals]
+
+    async def async_clear_signals(self) -> None:
+        """Clear the signal buffer."""
+
+        async with self._lock:
+            self._signals.clear()

--- a/custom_components/raspyrfm/manifest.json
+++ b/custom_components/raspyrfm/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "raspyrfm",
+  "name": "RaspyRFM",
+  "version": "0.1.0",
+  "documentation": "https://www.seegel-systeme.de/produkt/raspyrfm-ii/",
+  "requirements": [],
+  "codeowners": ["@seegel-systeme"],
+  "config_flow": true,
+  "iot_class": "local_push"
+}

--- a/custom_components/raspyrfm/panel.py
+++ b/custom_components/raspyrfm/panel.py
@@ -1,0 +1,48 @@
+"""Frontend panel registration for RaspyRFM."""
+
+from __future__ import annotations
+
+from importlib import resources
+from typing import Set
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import PANEL_ICON, PANEL_TITLE, PANEL_URL_PATH
+
+STATIC_PATH = "/raspyrfm_static"
+
+
+async def async_register_panel(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Register the RaspyRFM panel."""
+
+    entries: Set[str] = hass.data.setdefault("_raspyrfm_panel_entries", set())
+    if entry.entry_id in entries:
+        return
+
+    if not entries:
+        panel_path = resources.files(__package__).joinpath("frontend")
+        hass.http.register_static_path(STATIC_PATH, str(panel_path), cache_headers=False)
+        hass.components.frontend.async_register_panel(
+            component_name="custom",
+            frontend_url_path=PANEL_URL_PATH,
+            webcomponent_path=f"{STATIC_PATH}/raspyrfm-panel.js",
+            config={"name": PANEL_TITLE, "icon": PANEL_ICON},
+            require_admin=True,
+        )
+
+    entries.add(entry.entry_id)
+
+
+async def async_unregister_panel(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Unregister panel for a given entry."""
+
+    entries: Set[str] = hass.data.get("_raspyrfm_panel_entries", set())
+    entries.discard(entry.entry_id)
+
+    if entries:
+        return
+
+    hass.components.frontend.async_remove_panel(PANEL_URL_PATH)
+    hass.http.unregister_static_path(STATIC_PATH)
+    hass.data.pop("_raspyrfm_panel_entries", None)

--- a/custom_components/raspyrfm/storage.py
+++ b/custom_components/raspyrfm/storage.py
@@ -1,0 +1,107 @@
+"""Persistent storage for RaspyRFM devices."""
+
+"""Persistent storage helpers for RaspyRFM devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import STORAGE_KEY, STORAGE_VERSION
+
+
+@dataclass(slots=True)
+class RaspyRFMDeviceEntry:
+    """Representation of a configured device."""
+
+    device_id: str
+    name: str
+    device_type: str
+    signals: Dict[str, str]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a dictionary representation."""
+
+        return {
+            "device_id": self.device_id,
+            "name": self.name,
+            "device_type": self.device_type,
+            "signals": self.signals,
+            "metadata": self.metadata,
+        }
+
+    def matches_signal(self, payload: str) -> bool:
+        """Return True if the payload matches this device."""
+
+        return payload in self.signals.values()
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RaspyRFMDeviceEntry":
+        """Create an instance from stored data."""
+
+        return cls(
+            device_id=data["device_id"],
+            name=data["name"],
+            device_type=data.get("device_type", "switch"),
+            signals=data.get("signals", {}),
+            metadata=data.get("metadata", {}),
+        )
+
+
+class RaspyRFMDeviceStorage:
+    """Storage helper managing device persistence."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._hass = hass
+        self._store: Store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._devices: Dict[str, RaspyRFMDeviceEntry] = {}
+
+    async def async_load(self) -> None:
+        """Load device information from disk."""
+
+        data = await self._store.async_load()
+        if not data:
+            self._devices = {}
+            return
+
+        devices: List[RaspyRFMDeviceEntry] = [
+            RaspyRFMDeviceEntry.from_dict(item) for item in data.get("devices", [])
+        ]
+        self._devices = {device.device_id: device for device in devices}
+
+    async def async_unload(self) -> None:
+        """Flush changes to disk."""
+
+        await self._store.async_save({"devices": [device.to_dict() for device in self._devices.values()]})
+
+    def iter_devices(self) -> Iterable[RaspyRFMDeviceEntry]:
+        """Iterate over all devices."""
+
+        return list(self._devices.values())
+
+    def iter_devices_by_type(self, device_type: str) -> Iterable[RaspyRFMDeviceEntry]:
+        """Iterate over devices of a specific type."""
+
+        return [device for device in self._devices.values() if device.device_type == device_type]
+
+    def get_device(self, device_id: str) -> Optional[RaspyRFMDeviceEntry]:
+        """Return a device by id."""
+
+        return self._devices.get(device_id)
+
+    async def async_add_or_update(self, device: RaspyRFMDeviceEntry) -> None:
+        """Persist a device entry."""
+
+        self._devices[device.device_id] = device
+        await self._store.async_save({"devices": [d.to_dict() for d in self._devices.values()]})
+
+    async def async_remove(self, device_id: str) -> None:
+        """Remove a device entry."""
+
+        if device_id in self._devices:
+            self._devices.pop(device_id)
+            await self._store.async_save({"devices": [d.to_dict() for d in self._devices.values()]})

--- a/custom_components/raspyrfm/switch.py
+++ b/custom_components/raspyrfm/switch.py
@@ -1,0 +1,90 @@
+"""Switch platform for RaspyRFM."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import DOMAIN, SIGNAL_DEVICE_REGISTRY_UPDATED, SIGNAL_SIGNAL_RECEIVED
+from .entity import RaspyRFMEntity
+from .hub import RaspyRFMHub
+from .storage import RaspyRFMDeviceEntry
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    hub: RaspyRFMHub = hass.data[DOMAIN][entry.entry_id]
+    entities: Dict[str, RaspyRFMSwitch] = {}
+
+    @callback
+    def _ensure_entities() -> None:
+        new_entities = []
+        for device in hub.storage.iter_devices_by_type("switch"):
+            if device.device_id in entities:
+                continue
+            entity = RaspyRFMSwitch(hub, device)
+            entities[device.device_id] = entity
+            new_entities.append(entity)
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _ensure_entities()
+
+    @callback
+    def handle_device_update(device_id: str | None) -> None:
+        if device_id is None or device_id not in entities:
+            _ensure_entities()
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_DEVICE_REGISTRY_UPDATED, handle_device_update)
+    )
+
+
+class RaspyRFMSwitch(RaspyRFMEntity, SwitchEntity):
+    """Representation of a learned switch."""
+
+    def __init__(self, hub: RaspyRFMHub, device: RaspyRFMDeviceEntry) -> None:
+        super().__init__(hub, device)
+        self._attr_is_on = False
+        self._signal_unsub = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        @callback
+        def handle_signal(event: Dict[str, Any]) -> None:
+            payload = event.get("payload")
+            if payload == self._device.signals.get("on"):
+                self._attr_is_on = True
+                self.async_write_ha_state()
+            elif payload == self._device.signals.get("off"):
+                self._attr_is_on = False
+                self.async_write_ha_state()
+
+        self._signal_unsub = async_dispatcher_connect(
+            self.hass, SIGNAL_SIGNAL_RECEIVED, handle_signal
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._signal_unsub is not None:
+            self._signal_unsub()
+            self._signal_unsub = None
+        await super().async_will_remove_from_hass()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        signal = self._device.signals.get("on")
+        if signal is None:
+            raise ValueError("No ON signal stored for this device")
+        await self._hub.async_send_raw(signal)
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        signal = self._device.signals.get("off")
+        if signal is None:
+            raise ValueError("No OFF signal stored for this device")
+        await self._hub.async_send_raw(signal)
+        self._attr_is_on = False
+        self.async_write_ha_state()

--- a/custom_components/raspyrfm/translations/en.json
+++ b/custom_components/raspyrfm/translations/en.json
@@ -1,0 +1,29 @@
+{
+  "title": "RaspyRFM",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to RaspyRFM",
+        "description": "Provide the hostname or IP address of your RaspyRFM module.",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to contact the RaspyRFM gateway."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "RaspyRFM options",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/raspyrfm/websocket.py
+++ b/custom_components/raspyrfm/websocket.py
@@ -1,0 +1,193 @@
+"""Websocket commands exposed by the RaspyRFM integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.components import websocket_api
+
+from .const import (
+    DOMAIN,
+    SIGNAL_LEARNING_STATE,
+    SIGNAL_SIGNAL_RECEIVED,
+    WS_TYPE_DEVICE_CREATE,
+    WS_TYPE_DEVICE_DELETE,
+    WS_TYPE_DEVICE_LIST,
+    WS_TYPE_DEVICE_RELOAD,
+    WS_TYPE_LEARNING_START,
+    WS_TYPE_LEARNING_STATUS,
+    WS_TYPE_LEARNING_STOP,
+    WS_TYPE_LEARNING_SUBSCRIBE,
+    WS_TYPE_SIGNALS_LIST,
+    WS_TYPE_SIGNALS_SUBSCRIBE,
+)
+from .hub import RaspyRFMHub
+
+_LOGGER = logging.getLogger(__name__)
+
+HANDLERS_REGISTERED = "_raspyrfm_ws_handlers"
+
+
+def async_register_websocket_handlers(hass: HomeAssistant) -> None:
+    """Register websocket commands."""
+
+    if hass.data.get(HANDLERS_REGISTERED):
+        return
+
+    websocket_api.async_register_command(hass, handle_learning_start)
+    websocket_api.async_register_command(hass, handle_learning_stop)
+    websocket_api.async_register_command(hass, handle_learning_status)
+    websocket_api.async_register_command(hass, handle_learning_subscribe)
+    websocket_api.async_register_command(hass, handle_signals_list)
+    websocket_api.async_register_command(hass, handle_signals_subscribe)
+    websocket_api.async_register_command(hass, handle_device_create)
+    websocket_api.async_register_command(hass, handle_device_delete)
+    websocket_api.async_register_command(hass, handle_device_list)
+    websocket_api.async_register_command(hass, handle_device_reload)
+
+    hass.data[HANDLERS_REGISTERED] = True
+
+
+def _get_hub(hass: HomeAssistant, msg: Dict[str, Any]) -> RaspyRFMHub:
+    entry_id = msg.get("entry_id")
+    if entry_id is None:
+        # fallback to first entry
+        if DOMAIN not in hass.data or not hass.data[DOMAIN]:
+            raise websocket_api.HomeAssistantWebSocketError("No RaspyRFM entries configured")
+        entry_id = next(iter(hass.data[DOMAIN]))
+
+    hub = hass.data[DOMAIN].get(entry_id)
+    if hub is None:
+        raise websocket_api.HomeAssistantWebSocketError("Unknown RaspyRFM entry")
+    return hub
+
+
+@websocket_api.websocket_command({vol.Required("type"): WS_TYPE_LEARNING_START, vol.Optional("entry_id"): str})
+@websocket_api.async_response
+async def handle_learning_start(hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: Dict[str, Any]) -> None:
+    """Start capturing signals."""
+
+    hub = _get_hub(hass, msg)
+    await hub.async_start_learning()
+    connection.send_result(msg["id"], {"active": True})
+
+
+@websocket_api.websocket_command({vol.Required("type"): WS_TYPE_LEARNING_STOP, vol.Optional("entry_id"): str})
+@websocket_api.async_response
+async def handle_learning_stop(hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: Dict[str, Any]) -> None:
+    """Stop capturing signals."""
+
+    hub = _get_hub(hass, msg)
+    await hub.async_stop_learning()
+    connection.send_result(msg["id"], {"active": False})
+
+
+@websocket_api.websocket_command({vol.Required("type"): WS_TYPE_LEARNING_STATUS, vol.Optional("entry_id"): str})
+@websocket_api.async_response
+async def handle_learning_status(hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: Dict[str, Any]) -> None:
+    """Return the current learning state."""
+
+    hub = _get_hub(hass, msg)
+    connection.send_result(msg["id"], {"active": hub.learn_manager.is_active})
+
+
+@websocket_api.websocket_command({vol.Required("type"): WS_TYPE_LEARNING_SUBSCRIBE, vol.Optional("entry_id"): str})
+@callback
+def handle_learning_subscribe(hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: Dict[str, Any]) -> None:
+    """Subscribe to learning state updates."""
+
+    @callback
+    def forward(payload: Dict[str, Any]) -> None:
+        connection.send_message(websocket_api.event_message(msg["id"], payload))
+
+    connection.subscriptions[msg["id"]] = async_dispatcher_connect(
+        hass, SIGNAL_LEARNING_STATE, forward
+    )
+    connection.send_result(msg["id"])
+
+
+@websocket_api.websocket_command({vol.Required("type"): WS_TYPE_SIGNALS_LIST, vol.Optional("entry_id"): str})
+@websocket_api.async_response
+async def handle_signals_list(hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: Dict[str, Any]) -> None:
+    """Return a list of currently captured signals."""
+
+    hub = _get_hub(hass, msg)
+    signals = await hub.learn_manager.async_list_signals()
+    connection.send_result(msg["id"], {"signals": signals})
+
+
+@websocket_api.websocket_command({vol.Required("type"): WS_TYPE_SIGNALS_SUBSCRIBE, vol.Optional("entry_id"): str})
+@callback
+def handle_signals_subscribe(hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: Dict[str, Any]) -> None:
+    """Subscribe to incoming signals."""
+
+    @callback
+    def forward(payload: Dict[str, Any]) -> None:
+        connection.send_message(websocket_api.event_message(msg["id"], payload))
+
+    connection.subscriptions[msg["id"]] = async_dispatcher_connect(
+        hass, SIGNAL_SIGNAL_RECEIVED, forward
+    )
+    connection.send_result(msg["id"])
+
+
+_DEVICE_CREATE_SCHEMA = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
+    {
+        vol.Required("type"): WS_TYPE_DEVICE_CREATE,
+        vol.Required("name"): cv.string,
+        vol.Required("device_type"): vol.In(["switch", "binary_sensor"]),
+        vol.Required("signals"): {cv.string: cv.string},
+        vol.Optional("metadata"): {cv.string: cv.Any()},
+        vol.Optional("entry_id"): str,
+    }
+)
+
+
+@websocket_api.websocket_command(_DEVICE_CREATE_SCHEMA)
+@websocket_api.async_response
+async def handle_device_create(hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: Dict[str, Any]) -> None:
+    """Create a device from captured signals."""
+
+    hub = _get_hub(hass, msg)
+    device = await hub.async_create_device(msg["name"], msg["device_type"], msg["signals"], msg.get("metadata"))
+    connection.send_result(msg["id"], {"device": device.to_dict()})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_TYPE_DEVICE_DELETE,
+    vol.Required("device_id"): cv.string,
+    vol.Optional("entry_id"): str,
+})
+@websocket_api.async_response
+async def handle_device_delete(hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: Dict[str, Any]) -> None:
+    """Delete a stored device."""
+
+    hub = _get_hub(hass, msg)
+    await hub.async_remove_device(msg["device_id"])
+    connection.send_result(msg["id"], {})
+
+
+@websocket_api.websocket_command({vol.Required("type"): WS_TYPE_DEVICE_LIST, vol.Optional("entry_id"): str})
+@websocket_api.async_response
+async def handle_device_list(hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: Dict[str, Any]) -> None:
+    """Return the list of stored devices."""
+
+    hub = _get_hub(hass, msg)
+    devices = [device.to_dict() for device in hub.iter_devices()]
+    connection.send_result(msg["id"], {"devices": devices})
+
+
+@websocket_api.websocket_command({vol.Required("type"): WS_TYPE_DEVICE_RELOAD, vol.Optional("entry_id"): str})
+@websocket_api.async_response
+async def handle_device_reload(hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: Dict[str, Any]) -> None:
+    """Reload devices from persistent storage."""
+
+    hub = _get_hub(hass, msg)
+    await hub.async_reload_devices()
+    connection.send_result(msg["id"], {})


### PR DESCRIPTION
## Summary
- add a RaspyRFM custom Home Assistant integration with hub, storage, and websocket API helpers
- implement a learning manager to capture RF signals and register switch or binary sensor devices
- provide a frontend panel so users can start learning sessions, assign codes, and manage devices

## Testing
- not run (Home Assistant is not available in the test environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea7605a508326866ccf77a1c5c505)