### PR TITLE
Require OFF signal for RaspyRFM switches

### DIFF
--- a/custom_components/raspyrfm/frontend/raspyrfm-panel.js
+++ b/custom_components/raspyrfm/frontend/raspyrfm-panel.js
@@ -76,6 +76,10 @@ class RaspyRFMPanel extends LitElement {
         color: var(--error-color);
         margin-bottom: 12px;
       }
+      .required {
+        margin-left: 4px;
+        color: var(--error-color);
+      }
     `;
   }
 
@@ -218,8 +222,8 @@ class RaspyRFMPanel extends LitElement {
                   <span>${this.formOn || "Choose a captured signal"}</span>
                 </div>
                 <div class="form-row">
-                  <span class="pill">OFF</span>
-                  <span>${this.formOff || "Optional"}</span>
+                  <span class="pill">OFF<span class="required">*</span></span>
+                  <span>${this.formOff || "Choose a captured signal"}</span>
                 </div>
               `
             : html`
@@ -316,9 +320,11 @@ class RaspyRFMPanel extends LitElement {
         return;
       }
       signals.on = this.formOn;
-      if (this.formOff) {
-        signals.off = this.formOff;
+      if (!this.formOff) {
+        this.error = "Select an OFF signal for the switch.";
+        return;
       }
+      signals.off = this.formOff;
     } else {
       if (!this.formTrigger) {
         this.error = "Select a trigger signal for the sensor.";

--- a/custom_components/raspyrfm/switch.py
+++ b/custom_components/raspyrfm/switch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict
 
 from homeassistant.components.switch import SwitchEntity
@@ -12,6 +13,9 @@ from .const import DOMAIN, SIGNAL_DEVICE_REGISTRY_UPDATED, SIGNAL_SIGNAL_RECEIVE
 from .entity import RaspyRFMEntity
 from .hub import RaspyRFMHub
 from .storage import RaspyRFMDeviceEntry
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -84,7 +88,11 @@ class RaspyRFMSwitch(RaspyRFMEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         signal = self._device.signals.get("off")
         if signal is None:
-            raise ValueError("No OFF signal stored for this device")
+            _LOGGER.warning(
+                "Device %s has no OFF signal stored; ignoring turn_off request",
+                self._device.device_id,
+            )
+            return
         await self._hub.async_send_raw(signal)
         self._attr_is_on = False
         self.async_write_ha_state()


### PR DESCRIPTION
## Summary
- mark the RaspyRFM switch form's OFF signal as required and enforce validation
- guard switch turn_off handling when legacy devices lack an OFF payload

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ed04e883c8326bb5d924400746a80)