### PR TITLE
Require OFF signal for RaspyRFM switches

### DIFF
--- a/custom_components/raspyrfm/frontend/raspyrfm-panel.js
+++ b/custom_components/raspyrfm/frontend/raspyrfm-panel.js
@@ -76,6 +76,10 @@ class RaspyRFMPanel extends LitElement {
         color: var(--error-color);
         margin-bottom: 12px;
       }
+      .required {
+        margin-left: 4px;
+        color: var(--error-color);
+      }
     `;
   }
 
@@ -218,8 +222,8 @@ class RaspyRFMPanel extends LitElement {
                   <span>${this.formOn || "Choose a captured signal"}</span>
                 </div>
                 <div class="form-row">
-                  <span class="pill">OFF</span>
-                  <span>${this.formOff || "Optional"}</span>
+                  <span class="pill">OFF<span class="required">*</span></span>
+                  <span>${this.formOff || "Choose a captured signal"}</span>
                 </div>
               `
             : html`
@@ -316,9 +320,11 @@ class RaspyRFMPanel extends LitElement {
         return;
       }
       signals.on = this.formOn;
-      if (this.formOff) {
-        signals.off = this.formOff;
+      if (!this.formOff) {
+        this.error = "Select an OFF signal for the switch.";
+        return;
       }
+      signals.off = this.formOff;
     } else {
       if (!this.formTrigger) {
         this.error = "Select a trigger signal for the sensor.";

--- a/custom_components/raspyrfm/learn.py
+++ b/custom_components/raspyrfm/learn.py
@@ -6,10 +6,14 @@ import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from homeassistant.core import HomeAssistant
+
 from .const import DEFAULT_LISTEN_PORT
+
+if TYPE_CHECKING:
+    from .hub import RaspyRFMHub
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +41,7 @@ class LearnedSignal:
 class RaspyRFMLearnProtocol(asyncio.DatagramProtocol):
     """Asyncio datagram protocol for capturing signals."""
 
-    def __init__(self, manager: "LearnManager") -> None:
+    def __init__(self, manager: LearnManager) -> None:
         self._manager = manager
 
     def datagram_received(self, data: bytes, addr: Tuple[str, int]) -> None:
@@ -51,7 +55,7 @@ class RaspyRFMLearnProtocol(asyncio.DatagramProtocol):
 class LearnManager:
     """Manage RaspyRFM learning sessions."""
 
-    def __init__(self, hass: HomeAssistant, hub: "RaspyRFMHub") -> None:
+    def __init__(self, hass: HomeAssistant, hub: RaspyRFMHub) -> None:
         self._hass = hass
         self._hub = hub
         self._transport: Optional[asyncio.transports.DatagramTransport] = None

--- a/custom_components/raspyrfm/switch.py
+++ b/custom_components/raspyrfm/switch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict
 
 from homeassistant.components.switch import SwitchEntity
@@ -12,6 +13,9 @@ from .const import DOMAIN, SIGNAL_DEVICE_REGISTRY_UPDATED, SIGNAL_SIGNAL_RECEIVE
 from .entity import RaspyRFMEntity
 from .hub import RaspyRFMHub
 from .storage import RaspyRFMDeviceEntry
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -84,7 +88,11 @@ class RaspyRFMSwitch(RaspyRFMEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         signal = self._device.signals.get("off")
         if signal is None:
-            raise ValueError("No OFF signal stored for this device")
+            _LOGGER.warning(
+                "Device %s has no OFF signal stored; ignoring turn_off request",
+                self._device.device_id,
+            )
+            return
         await self._hub.async_send_raw(signal)
         self._attr_is_on = False
         self.async_write_ha_state()


### PR DESCRIPTION
## Summary
- mark the RaspyRFM switch form's OFF signal as required and enforce validation
- guard switch turn_off handling when legacy devices lack an OFF payload
- add conditional hub import for the learning helper so lint succeeds after the merge fix

## Testing
- poetry run pytest
- flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
- flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ed04e883c8326bb5d924400746a80)