### PR TITLE
Document RaspyRFM Home Assistant integration components

### DIFF
--- a/docs/source/homeassistant_components.rst
+++ b/docs/source/homeassistant_components.rst
@@ -1,0 +1,143 @@
+Home Assistant Components
+=========================
+
+This section documents the backend pieces that power the RaspyRFM
+Home Assistant integration.  Each subsection links to the relevant
+source files and explains how the pieces collaborate to monitor radio
+traffic, learn payloads, and expose entities inside Home Assistant.
+
+Configuration flow and setup
+----------------------------
+
+RaspyRFM is installed as a config entry.  The integration registers a
+config flow that resolves the gateway host name and persists the chosen
+UDP port.  Once an entry is created, ``async_setup_entry`` instantiates
+the hub, forwards platform setups, and makes the management panel and
+websocket commands available.
+
+.. literalinclude:: ../../custom_components/raspyrfm/config_flow.py
+   :language: python
+   :lines: 1-76
+
+.. literalinclude:: ../../custom_components/raspyrfm/__init__.py
+   :language: python
+   :lines: 1-74
+
+Gateway and hub orchestration
+-----------------------------
+
+The :class:`~custom_components.raspyrfm.gateway.RaspyRFMGateway` wraps the
+UDP socket used by the hardware bridge.  The hub owns a gateway instance
+and coordinates persistent storage, signal learning, and entity updates
+via Home Assistant dispatcher signals.
+
+.. literalinclude:: ../../custom_components/raspyrfm/gateway.py
+   :language: python
+   :lines: 1-60
+
+.. literalinclude:: ../../custom_components/raspyrfm/hub.py
+   :language: python
+   :lines: 1-220
+
+Signal learning pipeline
+------------------------
+
+The :class:`~custom_components.raspyrfm.learn.LearnManager` binds a UDP
+listener to ``DEFAULT_LISTEN_PORT`` (49881) and streams payloads into the
+hub.  Incoming packets are normalised into ``LearnedSignal`` dataclasses
+and broadcast over dispatcher events so that the UI and entity platforms
+receive live updates.
+
+.. literalinclude:: ../../custom_components/raspyrfm/learn.py
+   :language: python
+   :lines: 1-160
+
+Persistent storage and device registry
+--------------------------------------
+
+Two storage helpers manage device definitions and optional metadata about
+captured payloads.  The ``RaspyRFMDeviceStorage`` class keeps track of
+switches and binary sensors created from learned signals, while
+``RaspyRFMSignalMapStorage`` stores labels, semantic categories, and links
+between payloads and devices.
+
+.. literalinclude:: ../../custom_components/raspyrfm/storage.py
+   :language: python
+   :lines: 1-220
+
+Entity platforms
+----------------
+
+Both switches and binary sensors share a base entity class that listens
+for dispatcher updates when devices change.  The entity platforms iterate
+over stored devices, create entities on demand, and react to live signal
+messages from the learning pipeline.
+
+.. literalinclude:: ../../custom_components/raspyrfm/entity.py
+   :language: python
+   :lines: 1-80
+
+.. literalinclude:: ../../custom_components/raspyrfm/switch.py
+   :language: python
+   :lines: 1-160
+
+.. literalinclude:: ../../custom_components/raspyrfm/binary_sensor.py
+   :language: python
+   :lines: 1-160
+
+Websocket API surface
+---------------------
+
+The integration exposes a websocket namespace under ``raspyrfm/``.  The
+commands cover the full lifecycle: starting and stopping capture, listing
+signals, creating or deleting devices, and maintaining the optional
+signal mapping metadata.
+
+.. literalinclude:: ../../custom_components/raspyrfm/websocket.py
+   :language: python
+   :lines: 1-260
+
+Panel registration and static assets
+------------------------------------
+
+Every config entry registers a static path and serves a custom panel that
+is restricted to administrators.  The panel is implemented as a LitElement
+module that runs entirely inside the Home Assistant frontend.
+
+.. literalinclude:: ../../custom_components/raspyrfm/panel.py
+   :language: python
+   :lines: 1-120
+
+Frontend component
+------------------
+
+The ``raspyrfm-panel`` web component drives the onboarding experience for
+RaspyRFM users.  It exposes learning controls, renders cards summarising
+captured payloads, provides a device creation form, and lets users map
+payloads to semantic categories with optional device links.  The component
+relies exclusively on the websocket commands described above, so no
+additional backend endpoints are required.
+
+.. literalinclude:: ../../custom_components/raspyrfm/frontend/raspyrfm-panel.js
+   :language: javascript
+   :lines: 1-420
+
+Home Assistant integration checklist
+------------------------------------
+
+To use the integration in your own Home Assistant instance:
+
+1. Copy the ``custom_components/raspyrfm`` directory into your Home
+   Assistant ``config/custom_components`` folder.
+2. Restart Home Assistant so the new integration is discovered.
+3. Navigate to *Settings → Devices & Services* and add the RaspyRFM
+   integration.  Provide the host name or IP address of the RaspyRFM
+   gateway and the UDP port it listens on (``49880`` by default).
+4. Open the *RaspyRFM* panel from the sidebar to start a learning session
+   and capture payloads.  Use the *Create Home Assistant device* card to
+   turn them into entities, then link payloads to devices in the mapping
+   workspace.
+5. Optional: update the labels, categories, and device associations for
+   each payload in the mapping workspace.  The data is persisted through
+   ``.storage/raspyrfm_signal_map`` and is restored after Home Assistant
+   restarts.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,37 +5,34 @@ RaspyRFM Client Manual
    :hidden:
    :maxdepth: 2
 
+   homeassistant_components
    ui-guide
    raspyrfm_client
 
-.. container:: hero-card
+Overview
+--------
 
-   .. raw:: html
+RaspyRFM bridges inexpensive 433&nbsp;MHz receivers and transmitters with
+`Home Assistant <https://www.home-assistant.io/>`_.  The integration that
+ships with this repository contains:
 
-      <div class="hero-title">Visual tools for RaspyRFM automation</div>
+* A UDP ``gateway`` helper that speaks the RaspyRFM bridge protocol.
+* A ``hub`` coordinating the learn manager, persistent storage, and entity
+  registry updates inside Home Assistant.
+* Binary sensor and switch platforms that translate learned payloads into
+  Home Assistant entities.
+* A rich management panel implemented as a LitElement web component for
+  capturing, annotating, and replaying radio payloads.
 
-   .. raw:: html
+The sections below document how these pieces fit together and how you can
+adapt them for your own setup.
 
-      <p class="hero-subtitle">Build, map, and document your 433&nbsp;MHz Home Assistant devices with a refreshed design, live signal visualisations, and automatically published documentation.</p>
+Quick links
+~~~~~~~~~~~
 
-   - Explore the new signal mapping canvas to relate captured payloads with sensors and actuators.
-   - Capture screenshots and diagrams of the Home Assistant interface for quick onboarding.
-   - Publish the entire manual to GitHub Pages whenever the repository updates.
-
-Spotlight
----------
-
-.. grid:: 1 2 2 3
-   :gutter: 2
-
-   .. grid-item-card:: Guided configuration
-
-      The redesigned RaspyRFM control panel validates payloads in real time and explains the requirements for switches and binary sensors.
-
-   .. grid-item-card:: Signal topology mapping
-
-      Visually categorise incoming payloads as sensors, actuators, or miscellaneous signals and link them to the Home Assistant entities they drive.
-
-   .. grid-item-card:: Beautiful documentation
-
-      A modern theme, carefully tuned typography, and curated figures make the GitHub Pages site easy to read on desktop or mobile.
+* :doc:`homeassistant_components` – Backend components and Home Assistant
+  integration details.
+* :doc:`ui-guide` – Panels, cards, and mapping workspace provided by the
+  custom frontend.
+* :doc:`raspyrfm_client` – Python API reference for the reusable client
+  library.

--- a/docs/source/ui-guide.rst
+++ b/docs/source/ui-guide.rst
@@ -1,55 +1,95 @@
 Home Assistant Experience
 =========================
 
-The RaspyRFM Home Assistant panel now blends informative validation with live insights that help you
-understand each 433&nbsp;MHz payload. The screenshots and diagrams below are generated assets that mirror the
-refined user experience.
+The RaspyRFM panel is bundled with the integration and appears in the
+Home Assistant sidebar after you add a RaspyRFM config entry.  The panel
+is implemented as the ``raspyrfm-panel`` LitElement component and talks to
+Home Assistant exclusively through the websocket commands documented in
+:doc:`homeassistant_components`.
 
-.. container:: figure-grid
+Control strip
+-------------
 
-   .. figure:: _static/raspyrfm-switch-form.svg
-      :alt: RaspyRFM device creation form with required OFF signal
-      :figwidth: 100%
+A row of Material Web Components at the top of the panel exposes the
+core learning controls:
 
-      The device creation workflow emphasises that switches need both ON and OFF payloads before they can be saved.
+* **Start learning** – calls ``raspyrfm/learning/start`` and resets the
+  in-memory signal buffer.
+* **Stop learning** – calls ``raspyrfm/learning/stop`` and closes the
+  UDP listener created by the backend.
+* **Refresh devices** – pulls the current device list via
+  ``raspyrfm/devices/list`` and updates the entity cards without reloading
+  the page.
+* **Reload mapping** – refreshes the optional signal metadata with
+  ``raspyrfm/signals/map/list``.  When the mapping API is unavailable the
+  panel shows a non-blocking error banner.
 
-   .. figure:: _static/raspyrfm-device-list.svg
-      :alt: RaspyRFM device overview card in Home Assistant
-      :figwidth: 100%
+Captured signals card
+---------------------
 
-      A refreshed overview groups configured entities with their payload metadata for quick troubleshooting.
+Signals arriving through the learning pipeline are rendered inside the
+*Captured signals* card.  Each entry displays the raw payload, timestamp,
+source address, and action buttons that populate the device creation
+form.
 
-Signal Mapping Workspace
-========================
+.. figure:: _static/raspyrfm-switch-form.svg
+   :alt: RaspyRFM signal captured and assigned to a switch form
+   :figwidth: 100%
 
-The new graphical mapper turns the stream of learned payloads into a topology of sensors, actuators, and misc
-signals. You can assign friendly labels, associate payloads with stored RaspyRFM devices, and instantly see the
-resulting layout on the canvas.
+   Selecting **Set as ON/OFF/trigger** copies the payload into the
+   relevant field of the *Create Home Assistant device* card.
+
+Create Home Assistant device
+----------------------------
+
+The form on the right converts captured payloads into Home Assistant
+entities.  When the type is set to ``switch`` the RaspyRFM backend expects
+both ``on`` and ``off`` payloads; binary sensors accept a single
+``trigger`` payload.  Submitting the form calls
+``raspyrfm/device/create`` and automatically refreshes the device list and
+signal mapping state.
+
+.. figure:: _static/raspyrfm-switch-form.svg
+   :alt: RaspyRFM switch creation form highlighting required fields
+   :figwidth: 100%
+
+Signal mapping workspace
+------------------------
+
+The mapping workspace turns the ``raspyrfm/signals/map/*`` websocket API
+into an interactive editor.  Every payload is assigned to one of three
+categories—``sensor``, ``actuator``, or ``other``—and can optionally link
+back to stored devices.  The LitElement component keeps track of pending
+changes and only persists them when you press **Save mapping**.
 
 .. figure:: _static/raspyrfm-signal-mapping.svg
-   :alt: RaspyRFM signal mapping canvas mock-up
+   :alt: Signal mapping canvas showing payload categories
    :align: center
    :figwidth: 85%
-
-   Nodes are grouped into dedicated swimlanes so you always know which payloads feed sensors, actuators, or auxiliary workflows.
 
 .. figure:: _static/raspyrfm-mapping-editor.svg
-   :alt: RaspyRFM mapping editor mock-up
+   :alt: Signal mapping editor with label and device associations
    :align: center
    :figwidth: 85%
 
-   The editor couples category selectors and device toggles with save, reset, and delete controls to curate each payload.
+Device inventory
+----------------
 
-Documentation Theme Preview
-===========================
+Configured switches and binary sensors are listed in a dedicated card at
+the bottom of the panel.  Each entry shows the stored payloads, exposes a
+**Delete** button that triggers ``raspyrfm/device/delete``, and mirrors the
+state of the Home Assistant entities created by the integration.
 
-The GitHub Pages site uses the `Furo <https://pradyunsg.me/furo/>`_ theme with a custom accent palette and spacing tweaks that
-mirror the Home Assistant frontend.
+.. figure:: _static/raspyrfm-device-list.svg
+   :alt: RaspyRFM device overview card in Home Assistant
+   :figwidth: 100%
 
-.. container:: demo-highlight
+Styling
+-------
 
-   .. figure:: _static/raspyrfm-docs-theme.svg
-      :alt: RaspyRFM documentation theme sample page
-      :figwidth: 100%
-
-      Documentation cards now stretch across the page with generous white space and large typography for better readability on large displays.
+The panel ships with custom CSS that adopts Home Assistant's typography
+and card spacing while introducing rounded cards and subtle gradients for
+signal groupings.  The stylesheet lives alongside the Sphinx theme
+in ``docs/source/_static/raspyrfm.css`` and is referenced from the
+Furo theme configuration so the GitHub Pages site mirrors the in-app
+appearance.


### PR DESCRIPTION
## Summary
- add a Home Assistant components reference page that links directly to the integration source files
- refresh the documentation index to highlight backend integration and UI guides
- rewrite the UI guide to describe the RaspyRFM management panel, cards, and mapping workspace

## Testing
- make html *(fails: sphinx-build not installed in the CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f98b64f2083269c142cc775409a51)