### PR TITLE
Require off or dim payload for light devices

### DIFF
--- a/custom_components/raspyrfm/websocket.py
+++ b/custom_components/raspyrfm/websocket.py
@@ -264,6 +264,13 @@ def _validate_device_payload(device_type: str, signals: Dict[str, str]) -> None:
             f"Missing {', '.join(missing)} for {device_type}"
         )
 
+    if device_type == "light" and not any(
+        signals.get(key) for key in ("off", "dim")
+    ):
+        raise websocket_api.HomeAssistantWebSocketError(
+            "Provide either an OFF or DIM payload for light devices"
+        )
+
     unexpected = [
         key
         for key in signals


### PR DESCRIPTION
## Summary
- require that learned light payloads include an off or dim signal so they can turn off

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e48df168832692a5045b2432c450)