### PR TITLE
Remove redundant contents directive from package docs

### DIFF
--- a/docs/source/raspyrfm_client.rst
+++ b/docs/source/raspyrfm_client.rst
@@ -8,10 +8,6 @@ ships with base classes you can extend to model new radio-frequency hardware.
 This chapter now pairs narrative explanations, architecture diagrams, and API
 maps so you can move from concept to implementation without leaving the page.
 
-.. contents::
-   :local:
-   :depth: 2
-
 Overview
 --------
 


### PR DESCRIPTION
## Summary
- remove the local ``.. contents::`` directive from the package reference page so it no longer renders duplicate navigation entries under Furo

## Testing
- make -C docs html

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912004346548326aba0d30cec37dd17)