### PR TITLE
Fix SPI overlay guidance and manual extraction command

### DIFF
--- a/docs/source/raspyrfm_hardware_setup.rst
+++ b/docs/source/raspyrfm_hardware_setup.rst
@@ -111,7 +111,8 @@ enabled in ``config.txt``:
 
    The ``spi0-2cs`` overlay (or the Raspberry Pi OS default configuration with
    ``dtparam=spi=on`` alone) keeps both chip select lines enabled so the Twin
-   module can expose two radios.
+   module can expose two radios.  Avoid ``dtoverlay=spi0-1cs``—it disables the
+   second chip select and prevents ``/dev/spidev0.1`` from appearing.
 
 3. Save the file and safely eject the card.
 4. Reinsert the microSD card into the Raspberry Pi and connect power.


### PR DESCRIPTION
## Summary
- clarify the SPI overlay instructions so both chip selects remain enabled and warn against using spi0-1cs
- correct the manual custom component extraction command to reference the repository root within the archive

## Testing
- not run (documentation change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912705735fc8326b25b3b4799973c38)