### PR TITLE
Fix SPI overlay instruction and manual extraction command

### DIFF
--- a/docs/source/raspyrfm_hardware_setup.rst
+++ b/docs/source/raspyrfm_hardware_setup.rst
@@ -206,8 +206,8 @@ Carry out the following tasks in order.
          cd /config/custom_components
          mkdir -p raspyrfm
          curl -L https://github.com/raspyrfm/raspyrfm-client/archive/refs/heads/main.tar.gz \
-          | tar -xz --strip-components=2 -C raspyrfm \
-              raspyrfm-client-main/custom_components/raspyrfm
+          | tar -xz --strip-components=3 -C raspyrfm \
+             raspyrfm-client-main/custom_components/raspyrfm
 
       Restart Home Assistant after the files are in place.
    #. Add the integration, enter the Raspberry Pi's IP address, keep the default


### PR DESCRIPTION
## Summary
- ensure the SPI enablement instructions keep both chip select lines active for the Twin module by referencing the spi0-2cs overlay
- correct the manual Home Assistant installation command so the custom integration files are extracted from the GitHub archive into the raspyrfm directory

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912713ece2083269620dbd31436bd07)