### PR TITLE
Attach manufacturer constants to manufacturer alias

### DIFF
--- a/raspyrfm_client/device/__init__.py
+++ b/raspyrfm_client/device/__init__.py
@@ -56,17 +56,16 @@ def _mirror_package(alias: str, target: str) -> ModuleType:
 # Manufacturer subpackages --------------------------------------------------
 manufacturer = _mirror_package(__name__ + ".manufacturer", _MANUFACTURER_BASE)
 
-_alias_modules(
-    {
-        __name__ + ".manufacturer.manufacturer_constants": _MANUFACTURER_CONSTANTS,
-    }
-)
+_MANUFACTURER_ALIAS = __name__ + ".manufacturer"
+_MANUFACTURER_CONSTANTS_ALIAS = _MANUFACTURER_ALIAS + ".manufacturer_constants"
+
+_alias_modules({_MANUFACTURER_CONSTANTS_ALIAS: _MANUFACTURER_CONSTANTS})
 
 # ``manufacturer_constants`` used to live under ``raspyrfm_client.device.manufacturer``.
 # Mirror that attribute onto the exported ``manufacturer`` package so attribute
 # imports (``from raspyrfm_client.device.manufacturer import manufacturer_constants``)
 # continue to work alongside module level aliases.
-manufacturer.manufacturer_constants = import_module(_MANUFACTURER_CONSTANTS)
+setattr(manufacturer, "manufacturer_constants", sys.modules[_MANUFACTURER_CONSTANTS_ALIAS])
 
 for finder, name, ispkg in pkgutil.walk_packages(manufacturer.__path__, manufacturer.__name__ + "."):
     alias = name.replace(manufacturer.__name__, __name__ + ".manufacturer", 1)


### PR DESCRIPTION
## Summary
- cache the manufacturer alias paths to keep module names consistent
- attach the manufacturer_constants module to the exported manufacturer package so attribute imports succeed

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69136e46b7d0832683e40fe3afa17185)