### PR TITLE
Update dependencies for actions/setup-python, actions/checkout, and release-drafter

### DIFF
--- a/.github/workflows/python_publish.yaml
+++ b/.github/workflows/python_publish.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.github/workflows/python_publish.yaml
+++ b/.github/workflows/python_publish.yaml
@@ -33,4 +33,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}
+          # password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/python_publish.yaml
+++ b/.github/workflows/python_publish.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write  # Required for OIDC authentication
       contents: read   # Usually needed for checkout
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14.0-rc.3" ]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
           config-name: release-drafter.yml


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use newer versions of their respective actions and makes a minor change to the PyPI publish workflow. The main focus is on keeping CI dependencies up-to-date and improving workflow security and maintainability.

**GitHub Actions version upgrades:**
* Updated `actions/checkout` from v5 to v6 and `actions/setup-python` from v5 to v6 in both `.github/workflows/python_publish.yaml` and `.github/workflows/pythonpackage.yml` to use the latest features and security patches. [[1]](diffhunk://#diff-1454fba3a7eab0c1b993a26dc93565b1e1605200acf8d64fbdff1881991476c1L20-R22) [[2]](diffhunk://#diff-ee68bef8369ed7bc5460a288e72d62152784762ef66851e07bf134c4075a08f0L15-R17)
* Updated `release-drafter/release-drafter` from v6 to v7 in `.github/workflows/release_drafter.yml` for improved release note automation.

**PyPI publish workflow change:**
* Commented out the `password` line for PyPI publishing in `.github/workflows/python_publish.yaml`, possibly to change how authentication is handled.